### PR TITLE
support light status query

### DIFF
--- a/src/espcam_webserver.cpp
+++ b/src/espcam_webserver.cpp
@@ -12,6 +12,7 @@ espcam_webserver::espcam_webserver(OV2640 &cam, const String &instance_name)
 	server_.on("/jpg", HTTP_GET, std::bind(&espcam_webserver::handle_jpg, this));
 	server_.on("/lighton", HTTP_GET, std::bind(&espcam_webserver::handle_light_on, this));
 	server_.on("/lightoff", HTTP_GET, std::bind(&espcam_webserver::handle_light_off, this));
+	server_.on("/lightstatus", HTTP_GET, std::bind(&espcam_webserver::handle_light_status, this));
 }
 
 void espcam_webserver::begin()
@@ -128,4 +129,12 @@ void espcam_webserver::handle_light_off()
 	server_.sendHeader("Location", "/");
 	// See Other
 	server_.send(302);
+}
+
+void espcam_webserver::handle_light_status()
+{
+	log_i("handle_light_status");
+	bool on = digitalRead(LED_BUILTIN);
+
+	server_.send(200, "text/html", on ? "1" : "0");
 }

--- a/src/espcam_webserver.h
+++ b/src/espcam_webserver.h
@@ -19,6 +19,7 @@ private:
 	void handle_jpg();
 	void handle_light_on();
 	void handle_light_off();
+	void handle_light_status();
 
 public:
 	espcam_webserver(OV2640 &cam, const String &instance_name);


### PR DESCRIPTION
This is a small extension to query the current status of the flash light via http. This is useful for home automation like the [http switch plugin](https://www.npmjs.com/package/homebridge-http-switch) for [homebridge](https://homebridge.io).